### PR TITLE
Fix erroneous double quote in Seneca quote

### DIFF
--- a/quotes.js
+++ b/quotes.js
@@ -450,7 +450,7 @@ const quotes = [
     author: 'Seneca'
   },
   {
-    content: '“Let us prepare our minds as if we’d come to the very end of life. Let us postpone nothing. Let us balance life’s books each day. . . . The one who puts the finishing touches on their life each day is never short of time.',
+    content: 'Let us prepare our minds as if we’d come to the very end of life. Let us postpone nothing. Let us balance life’s books each day. . . . The one who puts the finishing touches on their life each day is never short of time.',
     reference: 'Moral letters, 101.7b–8a',
     author: 'Seneca'
   },


### PR DESCRIPTION
### Before
![broken](https://user-images.githubusercontent.com/1605754/88085424-6f638400-cb4b-11ea-9c64-01a38b03f2f5.png)

### After
![fixed](https://user-images.githubusercontent.com/1605754/88085439-74283800-cb4b-11ea-964f-c51474d29f27.png)
